### PR TITLE
Exercise 1.13 - fixed index out of bounds

### DIFF
--- a/chapter_1/exercise_1_13/histogram.c
+++ b/chapter_1/exercise_1_13/histogram.c
@@ -15,7 +15,7 @@ int main(void)
 
   // Initialize the histogram array with 0
   int i;
-  for (i = 0; i <= BUFFER; ++i)
+  for (i = 0; i < BUFFER; ++i)
   {
     histogram[i] = 0;
   }

--- a/chapter_1/exercise_1_13/histogram.c
+++ b/chapter_1/exercise_1_13/histogram.c
@@ -10,7 +10,6 @@ int main(void)
   int histogram[BUFFER];
   int histogram_length = 0;
 
-  int new_word = FALSE;
   int max_word_count = 0;
 
   // Initialize the histogram array with 0
@@ -28,9 +27,8 @@ int main(void)
   {
     if (c == ' ' || c == '\t' || c == '\n')
     {
-      if (!new_word)
+      if (word_count_index > 0)
       {
-        new_word = TRUE;
         ++histogram[word_count_index - 1];
 
         if (histogram[word_count_index - 1] > max_word_count)
@@ -48,7 +46,6 @@ int main(void)
     }
     else
     {
-      new_word = FALSE;
       ++word_count_index;
     }
   }


### PR DESCRIPTION
1. Fixed index out of bounds at initializing the array.

2. Fixed index out of bounds when input starts with spaces:
The array cell with index -1 is accessed during the first iteration of the for-loop if the input starts with spaces.
You can correct the initial value from **FALSE** to **TRUE** of the variable _new_word_ to solve the problem. But you can also refuse it because it is interconnected with the variable _word_count_index_ and use _word_count_index_ for the check.

This PR closes #22 issue.