### PR TITLE
Update Ex 1-24 to fix an issue

### DIFF
--- a/chapter_1/exercise_1_24/check_syntax.c
+++ b/chapter_1/exercise_1_24/check_syntax.c
@@ -44,7 +44,7 @@ void check_syntax(char str[])
   int line_comment = FALSE;
 
   int i = 0;
-  while (str[i] != '\0')
+  while (str[i] != '\0' && parentheses >= 0 && brackets >= 0 && braces >= 0)
   {
     if (!line_comment && !block_comment && !single_quotes && !double_quotes)
     {


### PR DESCRIPTION
Fixed solution for Ex. 1-24 that allowed for closing brackets before they are opened.

A case like ")))(((" is no longer considered balanced parenthesis, an error will now be printed.