### PR TITLE
Update Ex 1-23 to fix bug.

### DIFF
--- a/chapter_1/exercise_1_23/c_remove_comments.c
+++ b/chapter_1/exercise_1_23/c_remove_comments.c
@@ -74,7 +74,7 @@ void remove_comments(char str[], char no_com_str[])
         i += 2;
       }
 
-      if (str[i] == '/' && str[i] == '/')
+      if (str[i] == '/' && str[i + 1] == '/')
       {
         line_comment = TRUE;
       }


### PR DESCRIPTION
Fixed the exercise solution, so characters after a single / are no longer considered inline comments.
