### PR TITLE
Update c_remove_comments.c

### DIFF
--- a/chapter_1/exercise_1_23/c_remove_comments.c
+++ b/chapter_1/exercise_1_23/c_remove_comments.c
@@ -52,13 +52,16 @@ void remove_comments(char str[], char no_com_str[])
   int i = 0, j = 0;
   while (str[i] != '\0')
   {
-    if (!in_quote && str[i] == '"')
+    if (!block_comment)
+    {
+      if (!in_quote && str[i] == '"')
     {
       in_quote = TRUE;
     }
     else if (in_quote && str[i] == '"')
     {
       in_quote = FALSE;
+    }
     }
 
     if (!in_quote)


### PR DESCRIPTION
If there's any ` " ` present in the block comment,the program prints the all characters in that block_comment starting with the ` " `.
For example:
                      int main(void)
                      {
                        /**
                       *"
                       *
                       */
the output will contain:
                                    int main(void)
                                    {
                                       "
                                       *
                                       */
---------------------------------------------------------------------
The if-statement: 55: if(!block_comment) removes this bug.