### PR TITLE
Fixed uninitialized value

### DIFF
--- a/chapter_1/exercise_1_09/copy_io.c
+++ b/chapter_1/exercise_1_09/copy_io.c
@@ -3,7 +3,7 @@
 int main(void)
 {
   char c;
-  char last_c;
+  char last_c = '\0';
   while ((c = getchar()) != EOF)
   {
     if (c != ' ' || last_c != ' ')


### PR DESCRIPTION
Fixed the uninitialized value in chapter 1, exercise 9. If last_c was randomly assigned a space, a leading space would never be printed. The fix is to ensure that last_c is always initialized to a value that is not a space to prevent this situation.