### PR TITLE
Update escape.c

### DIFF
--- a/chapter_3/exercise_3_02/escape.c
+++ b/chapter_3/exercise_3_02/escape.c
@@ -1,189 +1,76 @@
-#include <stdio.h>
+/*
+ * Write a function escape(s,t) that converts characters like newline
+ * and tab into visible escape sequences like \n and \t as it copies
+ * the string t to s.Use a switch.Write a function for the other dire
+ * ction as well,converting escape sequences into the real characters.
+ */
 
-#define MAXLEN 1000
+#include<stdio.h>
+#define ON 1
+#define OFF 0
 
-int get_line(char line[], unsigned int limit);
-void escape(char dest[], char src[]);
-void unescape(char dest[], char src[]);
+void real()
+{
+        char c;
+        int ESCAPE = OFF;
+        while((c=getchar())!= '0')
+        {
+                if(ESCAPE) 
+                {
+
+                switch(c)
+
+                {
+                default: putchar(c);break;
+                case 'a': printf("\a"); break;
+                case 'b': printf("\b"); break;
+                case 'f': printf("\f"); break;
+                case 'n': printf("\n"); break;
+                case 'r': printf("\r"); break;
+                case 't': printf("\t"); break;
+                case 'v': printf("\v"); break;
+                case '\\':printf("\\"); break;
+                }
+
+                ESCAPE = OFF;
+
+                }
+
+                else 
+
+                {
+                if(c == '\\') ESCAPE = ON;
+                else
+                        putchar(c);
+                }
+        }
+
+}
+void escape()
+{
+        char c;
+        while((c=getchar())!= '0')
+        {
+
+        switch(c)
+ 
+        {
+        default  : putchar(c)   ;break;
+        case '\a': printf("\\a");break;
+        case '\b': printf("\\b");break;            
+        case '\f': printf("\\f");break;
+        case '\n': printf("\\n\n");break;
+        case '\r': printf("\\r");break;
+        case '\t': printf("\\t");break;
+        case '\v': printf("\\v");break;
+        }
+        }
+}
 
 int main(void)
 {
-  char src[MAXLEN];
-  char dest[MAXLEN];
-
-  get_line(src, MAXLEN);
-  printf("%s", src);
-
-  escape(dest, src);
-  printf("%s\n", dest);
-
-  unescape(dest, src);
-  printf("%s", dest);
-
-  return 0;
-}
-
-int get_line(char line[], unsigned int limit)
-{
-  int i, c;
-  for (i = 0; i < limit - 1 && (c = getchar()) != EOF && c != '\n'; ++i)
-  {
-    line[i] = c;
-  }
-
-  if (c == '\n')
-  {
-    line[i++] = c;
-  }
-
-  line[i] = '\0';
-
-  return i;
-}
-
-void escape(char dest[], char src[])
-{
-  int i, j;
-  for (i = j = 0; src[i] != '\0'; ++i, ++j)
-  {
-    switch (src[i])
-    {
-    case '\a':
-      dest[j++] = '\\';
-      dest[j] = 'a';
-      break;
-
-    case '\b':
-      dest[j++] = '\\';
-      dest[j] = 'b';
-      break;
-
-    case '\f':
-      dest[j++] = '\\';
-      dest[j] = 'f';
-      break;
-
-    case '\n':
-      dest[j++] = '\\';
-      dest[j] = 'n';
-      break;
-
-    case '\r':
-      dest[j++] = '\\';
-      dest[j] = 'r';
-      break;
-
-    case '\t':
-      dest[j++] = '\\';
-      dest[j] = 't';
-      break;
-
-    case '\v':
-      dest[j++] = '\\';
-      dest[j] = 'n';
-      break;
-
-    case '\\':
-      dest[j++] = '\\';
-      dest[j] = '\\';
-      break;
-
-    case '\?':
-      dest[j++] = '\\';
-      dest[j] = '?';
-      break;
-
-    case '\'':
-      dest[j++] = '\\';
-      dest[j] = '\'';
-      break;
-
-    case '\"':
-      dest[j++] = '\\';
-      dest[j] = '"';
-      break;
-
-    default:
-      dest[j] = src[i];
-      break;
-    }
-  }
-
-  if (src[i] == '\0')
-  {
-    dest[i] = src[i];
-  }
-}
-
-void unescape(char dest[], char src[])
-{
-  int i, j;
-  for (i = j = 0; src[i] != '\0'; ++i, ++j)
-  {
-    switch (src[i])
-    {
-    case '\\':
-      switch (src[++i])
-      {
-      case 'a':
-        dest[j] = '\a';
-        break;
-
-      case 'b':
-        dest[j] = '\b';
-        break;
-
-      case 'f':
-        dest[j] = '\f';
-        break;
-
-      case 'n':
-        dest[j] = '\n';
-        break;
-
-      case 'r':
-        dest[j] = '\r';
-        break;
-
-      case 't':
-        dest[j] = '\t';
-        break;
-
-      case 'v':
-        dest[j] = '\v';
-        break;
-
-      case '\\':
-        dest[j] = '\\';
-        break;
-
-      case '?':
-        dest[j] = '\?';
-        break;
-
-      case '\'':
-        dest[j] = '\'';
-        break;
-
-      case '"':
-        dest[j] = '\"';
-        break;
-
-      default:
-        dest[j++] = '\\';
-        dest[j] = src[i];
-        break;
-      }
-      break;
-
-    default:
-      dest[j] = src[i];
-      break;
-    }
-  }
-
-  if (src[i] == '\0')
-  {
-    dest[i] = src[i];
-  }
+        puts("Enter zero(0) to quit");
+        puts("escape : converts escape characters to visible escape sequences\n"); escape();
+        puts("Enter zero(0) to quit");
+        puts("\nreal : converts visible escape sequences to escape characters\n"); real();
 }


### PR DESCRIPTION
escape.c has many bugs:
It cannot properly handle the sequences such as:
hello\\world
hello\\tworld
hello\\\world

It prints an extra backslash(\) for the escape function: $./a.out
>hello world
>>hello world  //printf
>>hello world\  /* shouldn't print an extra backslash */
>>hello world //unescape

Furthermore,I think my way is quite simpler and tidy.