### PR TITLE
fixed typo

### DIFF
--- a/chapter_3/exercise_3_02/escape.c
+++ b/chapter_3/exercise_3_02/escape.c
@@ -80,7 +80,7 @@ void escape(char dest[], char src[])
 
     case '\v':
       dest[j++] = '\\';
-      dest[j] = 'n';
+      dest[j] = 'v';
       break;
 
     case '\\':
@@ -111,7 +111,7 @@ void escape(char dest[], char src[])
 
   if (src[i] == '\0')
   {
-    dest[i] = src[i];
+    dest[j] = src[i];
   }
 }
 
@@ -184,6 +184,6 @@ void unescape(char dest[], char src[])
 
   if (src[i] == '\0')
   {
-    dest[i] = src[i];
+    dest[j] = src[i];
   }
 }


### PR DESCRIPTION
There was a typo on a statement that was causing each vertical tab to print `'\n'` rather than `'\v'`. Maybe you wanted like that but I managed to change it anyway. Also `dest[i]= src[i]` causes some chars in dest to be overwritten if src contains a lot of escape chars. Did you mean `dest[j] = src[i]` instead?