### PR TITLE
fix 1-12

### DIFF
--- a/chapter_1/exercise_1_12/copy_io_nl.c
+++ b/chapter_1/exercise_1_12/copy_io_nl.c
@@ -1,18 +1,18 @@
-#include <stdio.h>                                                               
-                                                                                 
-int main()                                                                       
-{                                                                                
-        char c;                                                                  
-        char last_char = -1;                                                     
-        while ((c = getchar()) != EOF) {                                         
-                if(c==' ' || c=='\t' ||  c=='\n'){                               
-                        if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
-                                putchar('\n');                                   
-                        }                                                        
-                }                                                                
-                else {                                                           
-                        putchar(c);                                              
-                }       
-                last_char=c;
-        }                                                                        
-}        
+#include <stdio.h>
+
+int main()
+{
+  char c;
+  char last_char = -1;
+  while ((c = getchar()) != EOF) {
+    if(c==' ' || c=='\t' ||  c=='\n'){
+      if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
+        putchar('\n');
+      }
+    }
+    else {
+      putchar(c);
+    }
+    last_char=c;
+  }
+}

--- a/chapter_1/exercise_1_12/copy_io_nl.c
+++ b/chapter_1/exercise_1_12/copy_io_nl.c
@@ -4,6 +4,7 @@ int main()
 {
   char c;
   char last_char = -1;
+
   while ((c = getchar()) != EOF) {
     if(c==' ' || c=='\t' ||  c=='\n'){
       if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
@@ -15,4 +16,6 @@ int main()
     }
     last_char=c;
   }
+
+  return 0;
 }

--- a/chapter_1/exercise_1_12/copy_io_nl.c
+++ b/chapter_1/exercise_1_12/copy_io_nl.c
@@ -1,20 +1,19 @@
-#include <stdio.h>
-
-int main(void)
-{
-  char c;
-
-  while ((c = getchar()) != EOF)
-  {
-    if (c == ' ' || c == '\t' || c == '\n')
-    {
-      putchar('\n');
-    }
-    else
-    {
-      putchar(c);
-    }
-  }
-
-  return 0;
-}
+#include <stdio.h>                                                               
+                                                                                 
+int main()                                                                       
+{                                                                                
+        char c;                                                                  
+        char last_char = -1;                                                     
+        while ((c = getchar()) != EOF) {                                         
+                if(c==' ' || c=='\t' ||  c=='\n'){                               
+                        if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
+                                putchar('\n');                                   
+                        }                                                        
+                        last_char=c;                                             
+                }                                                                
+                else {                                                           
+                        putchar(c);                                              
+                        last_char=c;                                             
+                }                                                                
+        }                                                                        
+}        

--- a/chapter_1/exercise_1_12/copy_io_nl.c
+++ b/chapter_1/exercise_1_12/copy_io_nl.c
@@ -6,16 +6,18 @@ int main()
   char last_char = -1;
 
   while ((c = getchar()) != EOF) {
-    if(c==' ' || c=='\t' ||  c=='\n'){
-      if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
+    if((c==' ' ||  c=='\t' ||  c=='\n')) {
+      if(c != last_char) {
         putchar('\n');
       }
     }
     else {
       putchar(c);
     }
+
     last_char=c;
   }
 
   return 0;
 }
+

--- a/chapter_1/exercise_1_12/copy_io_nl.c
+++ b/chapter_1/exercise_1_12/copy_io_nl.c
@@ -9,11 +9,10 @@ int main()
                         if(last_char!=' ' &&  last_char!='\t' && last_char!='\n'){
                                 putchar('\n');                                   
                         }                                                        
-                        last_char=c;                                             
                 }                                                                
                 else {                                                           
                         putchar(c);                                              
-                        last_char=c;                                             
-                }                                                                
+                }       
+                last_char=c;
         }                                                                        
 }        


### PR DESCRIPTION
The program does not take into account if blank, tab or newlines are repeated. 

Example:
test.txt (notice blanks after 'This is a')
```
This is a   succession of blanks.
```

`./a.out < test.txt` 
```
This
is
a


succession
of
blanks.
```

whereas we expect

```
This
is
a
succession
of
blanks.
```