### PR TITLE
Fixed bugs in stack.c

### DIFF
--- a/chapter_4/exercise_4_04/stack.c
+++ b/chapter_4/exercise_4_04/stack.c
@@ -158,10 +158,16 @@ void swap(void)
 
 void clear(void)
 {
-  do
+/*  do
   {
     stack[sp] = 0.0;
   } while (sp--);
+*/
+  // Replacing the above commented code with this one ensures messages of "stack empty" aren't displayed an extra time after c command is called in the program
+  while (sp > 0)
+  {
+    stack[--sp] = 0.0;
+  }
 }
 
 int bufp = 0;
@@ -215,10 +221,11 @@ int getop(char s[])
       s[++i] = c = next;
     }
   }
-  else
+  // Remove this else block so that a value like 1200 in the program won't be mistaken is 100. This block will skip the second digit that is read in the number parsing process
+/*  else
   {
     c = getch();
-  }
+  }*/
 
   if (isdigit(c))
   {

--- a/chapter_4/exercise_4_04/stack.c
+++ b/chapter_4/exercise_4_04/stack.c
@@ -215,11 +215,6 @@ int getop(char s[])
       s[++i] = c = next;
     }
   }
-  // Remove this else block so that a value like 1200 in the program won't be mistaken is 100. This block will skip the second digit that is read in the number parsing process
-/*  else
-  {
-    c = getch();
-  }*/
 
   if (isdigit(c))
   {

--- a/chapter_4/exercise_4_04/stack.c
+++ b/chapter_4/exercise_4_04/stack.c
@@ -158,12 +158,6 @@ void swap(void)
 
 void clear(void)
 {
-/*  do
-  {
-    stack[sp] = 0.0;
-  } while (sp--);
-*/
-  // Replacing the above commented code with this one ensures messages of "stack empty" aren't displayed an extra time after c command is called in the program
   while (sp > 0)
   {
     stack[--sp] = 0.0;


### PR DESCRIPTION
Removed the else-block of "if (c == '-')" and restructured the clear command so the "stack is empty" message is not displayed an extra time after the c command has already been called. E.g if on the first line you type 'c', the message is displayed. On the next line, the message is displayed again even if you only typed "9 9+" because the previous code structure in the clear function forced the sp variable to go down to -1.