### PR TITLE
Optimized strcat.c

### DIFF
--- a/chapter_5/exercise_5_03/strcat.c
+++ b/chapter_5/exercise_5_03/strcat.c
@@ -18,10 +18,10 @@ int main(void)
 void strcat_ptr(char *s, char *t)
 {
   // Find the end of s
-  while ((*++s) != '\0')
-    ;
+  while (*s)
+      ++s;
 
   // copy t to the end of s
-  while ((*s++ = *t++) != '\0')
+  while (*s++ = *t++)
     ;
 }


### PR DESCRIPTION
In case s wasn't big enough for whatever reason, the function would still work with this optimized version. Also, for the purpose of compactness, comparing with the null-character can be omitted, e.g "if (x != '\0')" is the same as "if (x != 0)" which is the same as "if (x)".