### PR TITLE
Update strend.c

### DIFF
--- a/chapter_5/exercise_5_04/strend.c
+++ b/chapter_5/exercise_5_04/strend.c
@@ -32,8 +32,8 @@ int strend(char *s, char *t)
   size_t t_length = strlen(t);
 
   // Move the s & t pointer to the end of the corresponding strings.
-  s += s_length;
-  t += t_length;
+  s += s_length - 1;
+  t += t_length - 1;
 
   // Check backwards if each character from string t occurs in the corresonding
   // location from the string s.


### PR DESCRIPTION
By starting the comparison loop from '\0', you are making the t_length variable finish too early, leaving out the last letter unchecked for equality. Try 'printf("%d", strend("my cat", "dat"));' and you'll get an output of 1.