### PR TITLE
Fixed minor issue getop.c

### DIFF
--- a/chapter_5/exercise_5_06/getop.c
+++ b/chapter_5/exercise_5_06/getop.c
@@ -22,7 +22,7 @@ int getop(char *s)
   char c;
 
   // Skip blanks (spaces and tabs)
-  while ((*s = c = getchar()) != ' ' || c != '\t')
+  while ((*s = c = getchar()) == ' ' || c == '\t')
     ;
 
   *(s + 1) = '\0';


### PR DESCRIPTION
Changed '!=' to '==' so the skip white spaces thing happens.