### PR TITLE
Fix readlines.c

### DIFF
--- a/chapter_5/exercise_5_07/readlines.c
+++ b/chapter_5/exercise_5_07/readlines.c
@@ -48,7 +48,7 @@ int readlines(char *line_ptr[], int max_nr_of_lines, char *stored_lines)
   {
     // Checking if the current # of lines exceeds the max # of lines that can be stored
     // Also checking if the max # of chars from the stored_lines buffer is not exceeded
-    if (nr_of_lines >= max_nr_of_lines || (strlen(stored_lines) + len) > MAXSTORE)
+    if (nr_of_lines >= max_nr_of_lines || stored_lines + MAXSTORE - p < len)
     {
       return -1;
     }


### PR DESCRIPTION
At the test-part of the if-statement, please recall that we're checking for the *total* number of characters used in storage out of 10,000; we're not checking for the string-length of stored_lines added with the current line length being more than 10,000, especially when neither is stored_lines itself being changed in the program nor is the length of the current line allowed to be more than 1,000 to begin with.