### PR TITLE
Logic Error fixed in Solution

### DIFF
--- a/chapter_2/exercise_2_02/loop.c
+++ b/chapter_2/exercise_2_02/loop.c
@@ -19,22 +19,11 @@ int main(void)
   {
     char c = getchar();
 
-    if (i >= (MAXLINE - 1))
+    if (i >= (MAXLINE - 1) || c == '\n' || c == EOF)
     {
       loop = 0;
       break;
     }
-    else if (c == '\n')
-    {
-      loop = 0;
-      break;
-    }
-    else if (c == EOF)
-    {
-      loop = 0;
-      break;
-    }
-
     s[i++] = c;
   }
 

--- a/chapter_2/exercise_2_02/loop.c
+++ b/chapter_2/exercise_2_02/loop.c
@@ -23,6 +23,7 @@ int main(void)
     {
       loop = 0;
     }
+
     s[i++] = c;
   }
 

--- a/chapter_2/exercise_2_02/loop.c
+++ b/chapter_2/exercise_2_02/loop.c
@@ -22,14 +22,17 @@ int main(void)
     if (i >= (MAXLINE - 1))
     {
       loop = 0;
+      break;
     }
     else if (c == '\n')
     {
       loop = 0;
+      break;
     }
     else if (c == EOF)
     {
       loop = 0;
+      break;
     }
 
     s[i++] = c;

--- a/chapter_2/exercise_2_02/loop.c
+++ b/chapter_2/exercise_2_02/loop.c
@@ -22,7 +22,6 @@ int main(void)
     if (i >= (MAXLINE - 1) || c == '\n' || c == EOF)
     {
       loop = 0;
-      break;
     }
     s[i++] = c;
   }


### PR DESCRIPTION
The exercise asked to write a loop equivalent to the for loop that we used in getline() before in Chapter 1 without using && or ||.

![image](https://github.com/user-attachments/assets/afe51df4-852f-40c5-ac6b-ddbe2462ea13)

![image](https://github.com/user-attachments/assets/0c392236-ef24-4b21-a105-31f8c5cda64f)


The error that I fixed is that your solution doesn't have the same output as the old for loop for the same input. Your solution always add an extra character in the end of the string.

I avoided that problem by adding a break when the conditions are met.