### PR TITLE
fix: skip flushing read-only streams in file_close() and return 0 on success

### DIFF
--- a/chapter_8/exercise_8_03/syscalls.c
+++ b/chapter_8/exercise_8_03/syscalls.c
@@ -168,7 +168,7 @@ FILE *file_open(char *name, char *mode)
 
 int file_close(FILE *file_p)
 {
-  if (file_flush(file_p) == EOF)
+  if (file_p->flag._WRITE == 1 && file_flush(file_p) == EOF)
   {
     return EOF;
   }
@@ -179,7 +179,7 @@ int file_close(FILE *file_p)
   file_p->counter = 0;
   close(file_p->file_descriptor);
 
-  return NULL;
+  return 0;
 }
 
 int main(void)
@@ -204,6 +204,7 @@ int main(void)
   {
     putc(c, file_out_p);
   }
+  file_close(file_in_p);
   file_close(file_out_p);
 
   return EXIT_SUCCESS;

--- a/chapter_8/exercise_8_04/syscalls.c
+++ b/chapter_8/exercise_8_04/syscalls.c
@@ -168,7 +168,7 @@ FILE *file_open(char *name, char *mode)
 
 int file_close(FILE *file_p)
 {
-  if (file_flush(file_p) == EOF)
+  if (file_p->flag._WRITE == 1 && file_flush(file_p) == EOF)
   {
     return EOF;
   }
@@ -179,7 +179,7 @@ int file_close(FILE *file_p)
   file_p->counter = 0;
   close(file_p->file_descriptor);
 
-  return NULL;
+  return 0;
 }
 
 int file_seek(FILE *file_p, long offset, int whence)
@@ -227,6 +227,7 @@ int main(void)
   {
     putc(c, file_out_p);
   }
+  file_close(file_in_p);
   file_close(file_out_p);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Previously, file_close() always attempted to flush the file buffer even if the file was opened in read-only mode, which caused errors when there was no data to write. 
Additionally, it returned NULL instead of 0 on success.

This change adds a check to flush only when the _WRITE flag is set, and fixes the return value to 0 for a successful close.