### PR TITLE
Fix: Correctly count length of longer lines when including '\n'

### DIFF
--- a/chapter_1/exercise_1_16/longest_line.c
+++ b/chapter_1/exercise_1_16/longest_line.c
@@ -54,6 +54,10 @@ int get_line(char line[], int maxline)
     ++i;
     c = getchar();
   }
+  
+  if (c == '\n')
+    ++i;
+
   return i;
 }
 


### PR DESCRIPTION
The previous version of get_line did not increment the length counter for the final newline character when the line exceeded MAXLINE. This commit adds a check after counting the extra characters before EOF and '\n' Incrementing the counter if there was an escape sequence for newline