### PR TITLE
fixed error in entab that left more than minimum required spaces and tabs

### DIFF
--- a/chapter_1/exercise_1_21/entab.c
+++ b/chapter_1/exercise_1_21/entab.c
@@ -17,6 +17,9 @@ int main(void) {
                 putchar('\t');
                 nr_of_spaces = 0;
             }
+        } else if (c == '\t') {
+            nr_of_spaces = 0;
+            putchar(c);
         } else {
             while (nr_of_spaces) {
                 putchar(' ');

--- a/chapter_1/exercise_1_21/entab.c
+++ b/chapter_1/exercise_1_21/entab.c
@@ -8,10 +8,9 @@ int main(void) {
     unsigned int nr_of_spaces = 0;
 
     while ((c = getchar()) != EOF) {
-        ++line_pos;
-
         if (c == ' ') {
             ++nr_of_spaces;
+            ++line_pos;
 
             if (line_pos % TAB_LENGTH == 0 && nr_of_spaces > 1) {
                 putchar('\t');
@@ -20,12 +19,14 @@ int main(void) {
         } else if (c == '\t') {
             nr_of_spaces = 0;
             putchar(c);
+            line_pos += TAB_LENGTH - (line_pos % TAB_LENGTH);
         } else {
             while (nr_of_spaces) {
                 putchar(' ');
                 --nr_of_spaces;
             }
 
+            ++line_pos;
             if (c == '\n') {
                 line_pos = 0;
             }


### PR DESCRIPTION
I noticed that the included solution was leaving extra unneeded spaces where a tab would have just sufficed. For example, with the input "Hello, \t\t  \tWorld!" (just replace \t with the actual tab character to test that for example). Just added a base case to catch \t and insert them rather than inserting nr_spaces THEN the tab character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tab characters to preserve existing tabs in input while maintaining accurate line position tracking throughout processing.
  * Refined the space-to-tab conversion algorithm to better distinguish between tab and space characters during conversion.
  * Enhanced position management to correctly advance to the next tab stop when encountering tab characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->